### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
     ext_modules=[
         Extension(
             name='sphinxbase._sphinxbase',
-            sources=sb_sources,
+            sources=sorted(sb_sources),
             swig_opts=sb_swig_opts,
             include_dirs=sb_include_dirs,
             libraries=libraries,
@@ -159,7 +159,7 @@ setup(
         ),
         Extension(
             name='pocketsphinx._pocketsphinx',
-            sources=ps_sources,
+            sources=sorted(ps_sources),
             swig_opts=ps_swig_opts,
             include_dirs=sb_include_dirs + ps_include_dirs,
             libraries=libraries,


### PR DESCRIPTION
Sort input file list,
so that pocketsphinx-python's `_pocketsphinx.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

I found this when testing openSUSE's `python-pocketsphinx-python` package and noticed, that it produced a different `/usr/lib64/python2.7/site-packages/pocketsphinx/_pocketsphinx.so` for every build (happens in a disposable VM)