### PR TITLE
#55 Finding pocketsphinx model files when installed via pip.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ sudo python setup.py install
 
 Basic usage
 -----------
+NOTE: when pocketsphinx is installed via pip the model files and test data are not loaded when running the following script, Thus clone [pocketsphinx](https://github.com/cmusphinx/pocketsphinx.git) in the same directory, where this script is executed.
 
 ```python
 #!/usr/bin/env python


### PR DESCRIPTION
pip installation of pocketsphinx cannot find model files and data files when running the sample script. Manual clone/Download zip of the pocketsphinx repo provides such files to be loaded for the config.